### PR TITLE
parse all repos under the org, parse package.json, partial parsing of yarn berry lockfiles

### DIFF
--- a/cmd/parseall/main.go
+++ b/cmd/parseall/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/bencooper222/query-node-deps/pkg/db"
+	"github.com/bencooper222/query-node-deps/pkg/env"
+	gh "github.com/bencooper222/query-node-deps/pkg/github"
+	"github.com/bencooper222/query-node-deps/pkg/process"
+	"github.com/google/go-github/v45/github"
+	"golang.org/x/oauth2"
+)
+
+func main() {
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: env.Get("GITHUB_ACCESS_TOKEN", "not a token")},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+
+	client := github.NewClient(tc)
+	pgclient, _ := db.BuildPostgresClient("localhost", "postgres", "password", "postgres", "5432")
+
+	org := "convoyinc"
+
+	log.Print("Finding all the repos in ", org)
+	repos := gh.GetOrgRepos(*client, org)
+	log.Printf("Found %d repos", len(repos))
+
+	for i, repo := range repos {
+		log.Printf("(%d/%d) Pulling package.json+yarn.lock info for %s/%s", i, len(repos), org, repo.GetName())
+
+		err := process.ProcessLockAndPackageForLatestCommit(*client, pgclient, org, repo.GetName())
+		if err != nil {
+			if strings.Contains(err.Error(), "404 Not Found") {
+				log.Printf("package.json or yarn.lock not found for %s/%s", org, repo.GetName())
+			} else {
+				log.Printf("Error processing %s/%s, continuing. %s", org, repo.GetName(), err)
+			}
+		} else {
+			log.Printf("Processed %s/%s successfully", org, repo.GetName())
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "@yarnpkg/lockfile": "^1.1.0"
+    "@yarnpkg/lockfile": "^1.1.0",
+    "js-yaml": "^4.1.0"
   }
 }

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/bencooper222/query-node-deps/pkg/util"
@@ -44,7 +45,7 @@ func GetCommitDatetime(client gh.Client, org string, repo string, ref string) (t
 	return *refData.Commit.Committer.Date, nil
 }
 
-func GetLatestCommit(client gh.Client, org string, repo string, branch *string) (gh.RepositoryCommit, error) {
+func GetLatestCommit(client gh.Client, org string, repo string, branch *string) (*gh.RepositoryCommit, error) {
 	if branch == nil {
 		master := "master"
 		branch = &master
@@ -56,8 +57,47 @@ func GetLatestCommit(client gh.Client, org string, repo string, branch *string) 
 			PerPage: 1,
 		},
 	})
+	if err != nil {
+		if strings.Contains(err.Error(), "404 Not Found") {
+			// maybe the repo annoyingly has main as the default branch
+			refData, _, err = client.Repositories.ListCommits(ctx, org, repo, &gh.CommitsListOptions{
+				SHA: "main",
+				ListOptions: gh.ListOptions{
+					PerPage: 1,
+				},
+			})
+			if err != nil {
+				return nil, err
+			}
+			util.CheckErr(err)
+		} else {
+			return nil, err
+		}
+	}
+	return refData[0], nil
+}
 
-	util.CheckErr(err)
-
-	return *refData[0], nil
+func GetOrgRepos(client gh.Client, org string) []*gh.Repository {
+	ctx := context.Background()
+	opt := &gh.RepositoryListByOrgOptions{
+		ListOptions: gh.ListOptions{PerPage: 100},
+	}
+	var allNonArchivedRepos []*gh.Repository
+	i := 1
+	for {
+		repos, resp, err := client.Repositories.ListByOrg(ctx, org, opt)
+		util.CheckErr(err)
+		if resp.NextPage == 0 {
+			break
+		}
+		for _, repo := range repos {
+			if !*repo.Archived {
+				allNonArchivedRepos = append(allNonArchivedRepos, repo)
+			}
+		}
+		opt.Page = resp.NextPage
+		log.Printf("Listing repos %s, on page %d, found %d non-archived repos so far", org, i, len(allNonArchivedRepos))
+		i++
+	}
+	return allNonArchivedRepos
 }

--- a/pkg/lockfiles/types.go
+++ b/pkg/lockfiles/types.go
@@ -6,7 +6,7 @@ type Package struct {
 	ResolvedVersion   string
 }
 
-type JsonSchema struct {
+type YarnLockJsonSchema struct {
 	Type string `json:"type"`
 
 	Object map[string]struct {
@@ -16,3 +16,23 @@ type JsonSchema struct {
 		Dependencies map[string]string `json:"dependencies"`
 	} `json:"object"`
 }
+
+type YarnLockBerryJsonSchema map[string]interface{}
+
+type LockPackage struct {
+	Version      string            `json:"version"`
+	Resolution   string            `json:"resolution,omitempty"`
+	Dependencies map[string]string `json:"dependencies,omitempty"`
+	Checksum     string            `json:"checksum"`
+	LanguageName string            `json:"languageName"`
+	LinkType     string            `json:"linkType"`
+}
+
+// This was close to working and would be safer than assertion:
+// type YarnLockBerryJsonSchema struct {
+// 	Metadata struct {
+// 		Version  int `json:"version"`
+// 		CacheKey int `json:"cacheKey"`
+// 	} `json:"__metadata"`
+// 	Object map[string]LockPackage `json:"-"`
+// }

--- a/pkg/lockfiles/yarn.go
+++ b/pkg/lockfiles/yarn.go
@@ -5,25 +5,51 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/bencooper222/query-node-deps/pkg/util"
 	"github.com/google/uuid"
 )
 
-func GetParsedYarnLockfileFromLocalFile(loc string) []Package {
+func GetParsedYarnLockFileFromLocalFile(loc string) []Package {
 	arg := "node"
 	file := "./pkg/lockfiles/yarn/index.mjs"
 
 	cmd := exec.Command(arg, file, loc)
 	stdout, err := cmd.Output()
-	util.CheckErr(err)
+	if err != nil {
+		log.Fatalf("node command failed with stdout:\n%s\nerror: %v", stdout, err)
+	}
 
-	var parsedJson JsonSchema
-	json.Unmarshal(stdout, &parsedJson)
-
-	// log.Println(parsedJson.Object[])
-
+	var parsedJson YarnLockJsonSchema
+	err = json.Unmarshal(stdout, &parsedJson)
+	if err != nil {
+		log.Fatalf("failed to unmarshal json from stdout: %v", err)
+	}
+	if parsedJson.Object == nil {
+		// try berry format
+		var parsedBerryJson interface{}
+		err = json.Unmarshal(stdout, &parsedBerryJson)
+		if err != nil {
+			log.Fatalf("failed to unmarshal json from stdout: %v", err)
+		}
+		return convertRawYarnBerryLockfileToFilteredFormat(parsedBerryJson.(map[string]interface{}))
+	}
 	return convertRawYarnLockfileToFilteredFormat(parsedJson)
+
+}
+
+type packagejson struct {
+	Dependencies map[string]string `json:"dependencies"`
+}
+
+func GetPackageJSONDependencies(contents string) map[string]string {
+	var parsedJson packagejson
+	err := json.Unmarshal([]byte(contents), &parsedJson)
+	if err != nil {
+		log.Fatal("Problem unmarshalling package.json", err)
+	}
+	return parsedJson.Dependencies
 }
 
 func GetParsedYarnLockfileFromAlreadyStringifiedLockfile(contents string) []Package {
@@ -38,12 +64,11 @@ func GetParsedYarnLockfileFromAlreadyStringifiedLockfile(contents string) []Pack
 	f.WriteString(contents)
 	f.Sync()
 
-	return GetParsedYarnLockfileFromLocalFile("tmp/" + genUuid)
+	return GetParsedYarnLockFileFromLocalFile("tmp/" + genUuid)
 }
 
-func convertRawYarnLockfileToFilteredFormat(rawYarnLockfile JsonSchema) []Package {
+func convertRawYarnLockfileToFilteredFormat(rawYarnLockfile YarnLockJsonSchema) []Package {
 	obj := rawYarnLockfile.Object
-
 	var rtn []Package
 	for nameVersionSpec, info := range obj {
 		// deals with yarn spec lines that look like @thing/package@1.0.0
@@ -53,6 +78,26 @@ func convertRawYarnLockfileToFilteredFormat(rawYarnLockfile JsonSchema) []Packag
 			Name:              name,
 			SemverVersionSpec: versionSpec,
 			ResolvedVersion:   info.Version,
+		})
+	}
+
+	return rtn
+}
+
+func convertRawYarnBerryLockfileToFilteredFormat(rawYarnLockfile map[string]interface{}) []Package {
+	var rtn []Package
+	for nameVersionSpec, info := range rawYarnLockfile {
+		// deals with yarn spec lines that look like @thing/package@npm:1.0.0
+		// TODO: this will fail for resolve@patch:resolve@1.1.7#~builtin<compat/resolve>
+		name, versionSpec, matched := strings.Cut(nameVersionSpec, "@npm:")
+		if !matched {
+			log.Fatalf("could not parse name and version spec from %s", nameVersionSpec)
+		}
+
+		rtn = append(rtn, Package{
+			Name:              name,
+			SemverVersionSpec: versionSpec,
+			ResolvedVersion:   info.(map[string]interface{})["version"].(string),
 		})
 	}
 

--- a/pkg/lockfiles/yarn.go
+++ b/pkg/lockfiles/yarn.go
@@ -87,11 +87,19 @@ func convertRawYarnLockfileToFilteredFormat(rawYarnLockfile YarnLockJsonSchema) 
 func convertRawYarnBerryLockfileToFilteredFormat(rawYarnLockfile map[string]interface{}) []Package {
 	var rtn []Package
 	for nameVersionSpec, info := range rawYarnLockfile {
-		// deals with yarn spec lines that look like @thing/package@npm:1.0.0
+		if nameVersionSpec == "__metadata" {
+			continue
+		}
+
+		// Thisdeals with yarn spec lines that look like @thing/package@npm:1.0.0
 		// TODO: this will fail for resolve@patch:resolve@1.1.7#~builtin<compat/resolve>
 		name, versionSpec, matched := strings.Cut(nameVersionSpec, "@npm:")
 		if !matched {
-			log.Fatalf("could not parse name and version spec from %s", nameVersionSpec)
+			log.Printf("could not parse name and version spec from '%s', continuing with a mangled spec", nameVersionSpec)
+			name, versionSpec, matched = strings.Cut(nameVersionSpec, "@")
+			if !matched {
+				log.Fatalf("could not even find a @ in this, aborting")
+			}
 		}
 
 		rtn = append(rtn, Package{

--- a/pkg/lockfiles/yarn/index.mjs
+++ b/pkg/lockfiles/yarn/index.mjs
@@ -1,12 +1,25 @@
 // not worth rewriting this package in golang
 import lockfile from "@yarnpkg/lockfile";
 import { readFile } from "fs/promises";
+import yaml from "js-yaml";
 
+const file = await readFile(process.argv[2], "utf8");
 try {
-  const file = await readFile(process.argv[2], "utf8");
   const res = lockfile.parse(file);
   console.log(JSON.stringify(res));
 } catch (err) {
-  console.error(err);
-  process.exit(1);
+  if (err.message.startsWith('Unknown token')){
+    // yarn berry lockfiles can't be parsed by this, but are valid yaml:
+    //  https://github.com/yarnpkg/berry/issues/2671
+    try {
+      const obj = yaml.load(file);
+      console.log(JSON.stringify(obj));
+    } catch (err) {
+      console.log(err);
+      process.exit(1);
+    }
+  } else {
+    console.log(err);
+    process.exit(1);
+  }
 }

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ go run cmd/parseall/main.go
 This will attempt populate the db with the parsed lockfile and package.json info. Then you can connect to the dockerized postgres to query around.
 
 ```
-psql -U postgres -d postgres -h localhost -p 5432
+psql -U postgres -d postgres -h localhost -p 5432 #password=password
 ```
 
 ## Queries

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,43 @@
+# Query node deps
+
+This parses the package.json and yarn.lock of all packages at Convoy, recording their dependencies in a postgres database.
+
+
+## Setup
+
+First, get [golang](https://go.dev/). 
+
+Run these commands:
+
+
+```bash
+export GITHUB_ACCESS_TOKEN=$(printf "host=github.com\nprotocol=https\n" | git credential-osxkeychain get | grep "password" | cut -d= -f2)
+cd db-image && ./build-it.sh
+./run-it.sh
+cd ../
+go run cmd/migrate/main.go
+yarn
+```
+
+## Usage
+
+```bash
+go run cmd/parseall/main.go
+```
+
+This will attempt populate the db with the parsed lockfile and package.json info. Then you can connect to the dockerized postgres to query around.
+
+```
+psql -U postgres -d postgres -h localhost -p 5432
+```
+
+## Queries
+
+```sql
+-- find repos that depend directly on moment
+select distinct fully_qualified_git_slug from dependencies where name='moment' and source='PACKAGE_JSON';
+```
+
+## Known Limitations
+
+This will not properly parse yarn berry lockfiles (see yarn.go)

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,3 +6,15 @@
   version "1.1.0"
   resolved "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
   integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"


### PR DESCRIPTION
I got caught up on trying to parse the yarn berry lockfiles and wasn't able to get it working in every case. This isn't as clean as I'd like it, but I wanted to get what I had into a PR before I move on.

This PR:

* Looks up all the repos under the convoyinc org to parse all their dependency files
* Additionally parses package.json and pushes that data into the db
* Falls back to branch `main` if `master` 404s when trying to get the latest commit
* Falls back to trying to parse a yaml yarnlock with `js-yaml` if the lockfile parse fails
* Falls back to trying to navigate a yaml yarnlock json if the v1 parsing fails


## Future work

* Instead of trying yarn v1 and then falling back to v2 in two separate places, it'd be better to detect the yarn version and then split that logic higher up once.
* The process of listing all the repos and pulling down their lockfiles is very slow. There might be a way to cache things between runs so we don't have to do that every time
* We could use github's graphql API for getting the repositories as that would allow us to use less data transfer
* Fix parsing of complicated v2 yarnlock cases
* Navigate the graph of dependencies to provide insights, specifically I'm interested in the question "If I want to expunge/upgrade a package for everyone at Convoy, what order should I do it to minimize the number of PRs?"


